### PR TITLE
Follow symbolic links

### DIFF
--- a/lua/telescope-doc/init.lua
+++ b/lua/telescope-doc/init.lua
@@ -63,6 +63,7 @@ M.open = function()
     telescope.find_files({
         prompt_title = "Select Document",
         cwd = tbl.cwd,
+        follow = true,
 
         -- Handle file selection proccess
         attach_mappings = function(prompt_bufnr, map)
@@ -81,6 +82,7 @@ M.open_path = function(tbl)
     telescope.find_files({
         prompt_title = "Select Document",
         cwd = tbl.cwd,
+        follow = true,
 
         -- Handle file selection proccess
         attach_mappings = function(prompt_bufnr, map)


### PR DESCRIPTION
This is an attempt to follow symbolic links when searching. For instance, if I want to search through TeX documentation on macOS, I have to search from `/Library/TeX/Documentation`, but all subfolders in there are symbolic links.